### PR TITLE
Always upload qcow2 images

### DIFF
--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -40,17 +40,13 @@
           chmod +x mc
           ./mc alias set minio https://swift.services.a.regiocloud.tech {{ minio.MINIO_ACCESS_KEY | trim }} {{ minio.MINIO_SECRET_KEY | trim }}
 
-          sha256sum osism-{{ _dib_element }}-image.{{ _image_format }} > osism-{{ _dib_element }}-image.{{ _image_format }}.CHECKSUM
-          ./mc cp osism-{{ _dib_element }}-image.{{ _image_format }}.CHECKSUM minio/openstack-ironic-images
-
           if [[ "{{ _image_format }}" == "raw" ]]; then
-              bzip2 osism-{{ _dib_element }}-image.{{ _image_format }}
-              sha256sum osism-{{ _dib_element }}-image.{{ _image_format }}.bz2 > osism-{{ _dib_element }}-image.{{ _image_format }}.bz2.CHECKSUM
-              ./mc cp osism-{{ _dib_element }}-image.{{ _image_format }}.bz2 minio/openstack-ironic-images
-              ./mc cp osism-{{ _dib_element }}-image.{{ _image_format }}.bz2.CHECKSUM minio/openstack-ironic-images
-          else
-              ./mc cp osism-{{ _dib_element }}-image.{{ _image_format }} minio/openstack-ironic-images
+              qemu-img convert -O qcow2 osism-{{ _dib_element }}-image.{{ _image_format }} osism-{{ _dib_element }}-image.qcow2
           fi
+
+          sha256sum osism-{{ _dib_element }}-image.qcow2 > osism-{{ _dib_element }}-image.qcow2.CHECKSUM
+          ./mc cp osism-{{ _dib_element }}-image.qcow2.CHECKSUM minio/openstack-ironic-images
+          ./mc cp osism-{{ _dib_element }}-image.qcow2 minio/openstack-ironic-images
 
       when: upload_image | bool
       no_log: true


### PR DESCRIPTION
The image size of qcow2 is comparable with a bzip2 compressed raw image. But on the target nodes it's a lot faster to convert a qcow2 image into a raw image.

Revert parts of 41dcbc6cec50cadbdbb45f9d56db650bfbe7d55d