### PR TITLE
metalbox: move registry to port 5001

### DIFF
--- a/files/metalbox/part1.yml
+++ b/files/metalbox/part1.yml
@@ -115,7 +115,7 @@
     docker_version: '5:27.5.1'
     docker_facts: false
     docker_insecure_registries:
-      - localhost:5000
+      - localhost:5001
 
   roles:
     - osism.services.docker

--- a/files/metalbox/run.sh
+++ b/files/metalbox/run.sh
@@ -10,4 +10,4 @@ if [[ -e /opt/registry.tar.bz2 ]]; then
     docker run --rm -v registry:/volume -v /opt:/import alpine:3 sh -c 'cd /volume && tar xjf /import/registry.tar.bz2'
 fi
 
-docker run -d -p 5000:5000 -v registry:/var/lib/registry --name registry registry:3
+docker run -d -p 5001:5000 -v registry:/var/lib/registry --name registry registry:3


### PR DESCRIPTION
Port 5000 is required by the keystone service.