### PR TITLE
Use zip to compress raw images

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -55,6 +55,7 @@
       - "^elements/burnin/.*"
       - "^files/burnin.sh"
       - "^files/burnin/.*"
+      - "^playbooks/.*"
 
 - job:
     name: openstack-ironic-images-publish-burnin
@@ -72,6 +73,7 @@
       - "^elements/burnin/.*"
       - "^files/burnin.sh"
       - "^files/burnin/.*"
+      - "^playbooks/.*"
 
 - job:
     name: openstack-ironic-images-build-metalbox
@@ -83,6 +85,7 @@
       - "^elements/metalbox/.*"
       - "^files/metalbox.sh"
       - "^files/metalbox/.*"
+      - "^playbooks/.*"
 
 - job:
     name: openstack-ironic-images-publish-metalbox
@@ -100,6 +103,7 @@
       - "^elements/metalbox/.*"
       - "^files/metalbox.sh"
       - "^files/metalbox/.*"
+      - "^playbooks/.*"
 
 - project:
     merge-mode: squash-merge

--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -40,13 +40,15 @@
           chmod +x mc
           ./mc alias set minio https://swift.services.a.regiocloud.tech {{ minio.MINIO_ACCESS_KEY | trim }} {{ minio.MINIO_SECRET_KEY | trim }}
 
-          if [[ "{{ _image_format }}" == "raw" ]]; then
-              qemu-img convert -O qcow2 osism-{{ _dib_element }}-image.{{ _image_format }} osism-{{ _dib_element }}-image.qcow2
-          fi
+          sha256sum osism-{{ _dib_element }}-image.{{ _image_format }} osism-{{ _dib_element }}-image.{{ _image_format }}.CHECKSUM
 
-          sha256sum osism-{{ _dib_element }}-image.qcow2 > osism-{{ _dib_element }}-image.qcow2.CHECKSUM
-          ./mc cp osism-{{ _dib_element }}-image.qcow2.CHECKSUM minio/openstack-ironic-images
-          ./mc cp osism-{{ _dib_element }}-image.qcow2 minio/openstack-ironic-images
+          if [[ "{{ _image_format }}" == "raw" ]]; then
+              zip osism-{{ _dib_element }}-image.zip osism-{{ _dib_element }}-image.{{ _image_format }} osism-{{ _dib_element }}-image.{{ _image_format }}.CHECKSUM
+              ./mc cp osism-{{ _dib_element }}-image.zip minio/openstack-ironic-images
+          else
+              ./mc cp osism-{{ _dib_element }}-image.{{ _image_format }}.CHECKSUM minio/openstack-ironic-images
+              ./mc cp osism-{{ _dib_element }}-image.{{ _image_format }} minio/openstack-ironic-images
+          fi
 
       when: upload_image | bool
       no_log: true

--- a/playbooks/pre.yml
+++ b/playbooks/pre.yml
@@ -18,6 +18,7 @@
           - kpartx
           - qemu-utils
           - squashfs-tools
+          - zip
 
     - name: Install requirements
       ansible.builtin.pip:


### PR DESCRIPTION
This makes it easier to extract the images on Windows instances.