### PR TITLE
Fix osism-node upload job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -135,11 +135,12 @@
 
 - job:
     name: openstack-ironic-images-publish-osism-node
-    parent: abstract-openstack-ironic-images-publish
+    parent: openstack-ironic-images-build-osism-node
     semaphores:
       - name: semaphore-openstack-ironic-images-publish-osism-node
     vars:
       build_name: osism-node
+      upload_image: true
     secrets:
       - name: minio
         secret: SECRET_OPENSTACK_IRONIC_IMAGES


### PR DESCRIPTION
Need to use openstack-ironic-images-build-osism-node as parent for now so that the correct playbooks are getting executed.