### PR TITLE
metalbox: add static metalbox hosts entry

### DIFF
--- a/elements/metalbox/static/root/part1.yml
+++ b/elements/metalbox/static/root/part1.yml
@@ -84,8 +84,10 @@
 
     # hosts
     hosts_type: template
+    hosts_group_name: none
     hosts_additional_entries:
       api.metalbox.osism.xyz: 192.168.42.10
+      metalbox: 192.168.42.10
 
   roles:
     - osism.commons.hostname


### PR DESCRIPTION
This way it can be ensured that no other entries will show up in /etc/hosts.