### PR TITLE
Install bootloader to $EFI_BOOT_DIR in node image

### DIFF
--- a/elements/osism-node/finalise.d/60-grub
+++ b/elements/osism-node/finalise.d/60-grub
@@ -9,10 +9,11 @@ set -o pipefail
 
 # TODO(frickler): avoid this workaround
 if [ -f /boot/grub/x86_64-efi/mdraid1x.mod ]; then
-    cp /boot/grub/x86_64-efi/mdraid1x.mod /boot/efi/EFI/BOOT
+    mkdir -p /boot/efi/$EFI_BOOT_DIR
+    cp /boot/grub/x86_64-efi/mdraid1x.mod /boot/efi/$EFI_BOOT_DIR
 fi
 
 rm -f /etc/default/grub.d/50-cloudimg-settings.cfg
 update-grub
-grub-install --modules=mdraid1x -v
-
+grub-install --no-nvram --modules=mdraid1x -v $EFI_BOOT_DIR
+rm -rf /boot/efi/EFI/BOOT


### PR DESCRIPTION
CISCO hardware seems to prefer the UEFI fallback path in `EFI\BOOT` to automatically create UEFI boot entries, while discarding manually created entries.
As a workaround we explicitly install to the disitribution specific path specified in the `EFI_BOOT_DIR` variable by the `ubuntu-common` element. The fallback path is explicitly deleted afterwards.

Additionally the `--no-nvram` options is set to avoid trying to create UEFI boot entries during image build.
