### PR TITLE
Add osism-ipa-stable jobs to the project

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -229,6 +229,7 @@
         - openstack-ironic-images-build-burnin
         - openstack-ironic-images-build-metalbox
         - openstack-ironic-images-build-osism-ipa
+        - openstack-ironic-images-build-osism-ipa-stable
         - openstack-ironic-images-build-osism-node
         - yamllint
     periodic-daily:
@@ -241,6 +242,8 @@
         - openstack-ironic-images-publish-metalbox:
             branches: main
         - openstack-ironic-images-publish-osism-ipa:
+            branches: main
+        - openstack-ironic-images-publish-osism-ipa-stable:
             branches: main
         - openstack-ironic-images-publish-osism-node:
             branches: main

--- a/playbooks/builder.yml
+++ b/playbooks/builder.yml
@@ -17,7 +17,7 @@
           set -x
 
           git clone https://opendev.org/openstack/ironic-python-agent-builder
-      when: _build_name == "osism-ipa"
+      when: _build_name | regex_search("^osism-ipa")
 
     - name: Run diskimage-builder
       ansible.builtin.shell:


### PR DESCRIPTION
It helps to have jobs in pipelines if the intention is for them to get executed.