### PR TITLE
Remove timeout from oneshot systemd units

### DIFF
--- a/elements/ansible-init/init-scripts/systemd/ansible-init.service
+++ b/elements/ansible-init/init-scripts/systemd/ansible-init.service
@@ -5,7 +5,6 @@ Description=Ansible Init
 ExecStart=/usr/local/sbin/ansible-init
 Type=oneshot
 RemainAfterExit=yes
-TimeoutSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/elements/osism-ipa/init-scripts/systemd/osism-ipa-config.service
+++ b/elements/osism-ipa/init-scripts/systemd/osism-ipa-config.service
@@ -5,7 +5,6 @@ Description=OSISM IPA Config Generation
 ExecStart=/usr/local/sbin/osism-ipa-configure
 Type=oneshot
 RemainAfterExit=yes
-TimeoutSec=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The given timeout is to short for the init playbook to complete. The default timeout for units of type `oneshot` is infinity ([1]), which is probably what we want here.

[1]
https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#TimeoutSec= https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#TimeoutStartSec=