### PR TITLE
Do not install HWE kernel in metalbox image

### DIFF
--- a/elements/metalbox/static/root/part1.yml
+++ b/elements/metalbox/static/root/part1.yml
@@ -66,7 +66,6 @@
       - htop
       - ipmitool
       - iptables
-      - linux-generic-hwe-24.04
       - net-tools
       - python3-netaddr
       - rsync


### PR DESCRIPTION
The current 6.14.0-27 HWE kernel causes sporadic freezes during boot when the ESP partition device is activated by systemd. Since previous HWE kernel versions are not available anymore, we fall back to not installing the HWE kernel at all.