### PR TITLE
Add burn-in element to IPA

### DIFF
--- a/files/osism-ipa-stable.yml
+++ b/files/osism-ipa-stable.yml
@@ -7,6 +7,7 @@
   elements:
     - ubuntu
     - ironic-python-agent-ramdisk
+    - burn-in
     - openssh-server
     - devuser
     - osism-ipa

--- a/files/osism-ipa.yml
+++ b/files/osism-ipa.yml
@@ -7,6 +7,7 @@
   elements:
     - ubuntu
     - ironic-python-agent-ramdisk
+    - burn-in
     - openssh-server
     - devuser
     - osism-ipa


### PR DESCRIPTION
The `burn-in` element install required packages like `stress-ng` and `fio`.