### PR TITLE
osism-ipa: run osism-ipa-config.service after network.target

### DIFF
--- a/elements/osism-ipa/init-scripts/systemd/osism-ipa-config.service
+++ b/elements/osism-ipa/init-scripts/systemd/osism-ipa-config.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=OSISM IPA Config Generation
+After=network.target
 
 [Service]
 ExecStart=/usr/local/sbin/osism-ipa-configure


### PR DESCRIPTION
This way all network interfaces should be visible.