### PR TITLE
osism-ipa: improve network initialization reliability

### DIFF
--- a/elements/osism-ipa/init-scripts/systemd/osism-ipa-config.service
+++ b/elements/osism-ipa/init-scripts/systemd/osism-ipa-config.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=OSISM IPA Config Generation
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 ExecStart=/usr/local/sbin/osism-ipa-configure

--- a/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
+++ b/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
@@ -65,9 +65,24 @@ def restart_networking():
 def main():
     data = {}
     print("Before scan_interfaces()")
-    interfaces = scan_interfaces()
-    data["osism_interfaces"] = [interface[0] for interface in interfaces]
-    data["osism_ipv6"] = "fd33:fd0e:2aee:0:%s" % interfaces[0][1]
+
+    attempt = 0
+    max_retries = 5
+    while attempt < max_retries:
+        try:
+            interfaces = scan_interfaces()
+            data["osism_interfaces"] = [interface[0] for interface in interfaces]
+            data["osism_ipv6"] = "fd33:fd0e:2aee:0:%s" % interfaces[0][1]
+            break
+        except IndexError:
+            attempt += 1
+            if attempt < max_retries:
+                print(
+                    f"Network interfaces not yet correctly available. Attempt {attempt}/{max_retries}. Try again in 20 seconds."
+                )
+                time.sleep(20)
+            else:
+                raise
 
     print("Before write_config_files()")
     write_config_files(data)


### PR DESCRIPTION
- Change service dependency from network.target to network-online.target for better network readiness
- Add retry logic to handle cases where network interfaces aren't immediately available
- Implement 3 retry attempts with 20-second delays to ensure network stability