### PR TITLE
osism-ipa: improve network initialization reliability

### DIFF
--- a/elements/osism-ipa/init-scripts/systemd/osism-ipa-config.service
+++ b/elements/osism-ipa/init-scripts/systemd/osism-ipa-config.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=OSISM IPA Config Generation
-After=network-online.target
+After=network-online.target systemd-networkd.service systemd-udev-settle.service
 Wants=network-online.target
 
 [Service]

--- a/elements/osism-ipa/post-install.d/80-osism
+++ b/elements/osism-ipa/post-install.d/80-osism
@@ -8,8 +8,9 @@ set -o pipefail
 
 case "$DIB_INIT_SYSTEM" in
     systemd)
-        systemctl enable osism-ipa-config.service
+	systemctl enable systemd-udev-settle.service
         systemctl disable ironic-python-agent.service
+        systemctl enable osism-ipa-config.service
         ;;
     *)
         echo "Unsupported init system $DIB_INIT_SYSTEM"


### PR DESCRIPTION
Add systemd-networkd.service and systemd-udev-settle.service dependencies to ensure proper network interface initialization before config generation.