### PR TITLE
ansible-init: ignore unmount errors for config drive

### DIFF
--- a/elements/ansible-init/static/usr/local/sbin/ansible-init
+++ b/elements/ansible-init/static/usr/local/sbin/ansible-init
@@ -19,7 +19,7 @@ def unmount_config_drive():
     config_drive = "/dev/disk/by-label/config-2"
 
     subprocess.run(["umount", config_drive],
-                   check=True)
+                   check=False)
 
 def apply_config():
     with open("/var/log/ansible.out","w") as outpipe:


### PR DESCRIPTION
Allow the config drive unmount operation to fail gracefully rather than causing the script to exit. This prevents issues when the config drive is already unmounted or not available.