### PR TITLE
Add IPA OOB Variant

### DIFF
--- a/elements/osism-ipa/static/opt/osism/templates/osism-netplan.yaml.j2
+++ b/elements/osism-ipa/static/opt/osism/templates/osism-netplan.yaml.j2
@@ -21,10 +21,8 @@ network:
 
 {% elif variant == 'OOB' %}
   ethernets:
-    eno1:
+    {{ osism_onboard_interface }}:
         mtu: 1500
-        match:
-            name: eno*
         addresses:
         - {{ osism_ipv6 }}/64
 {% endif %}

--- a/elements/osism-ipa/static/opt/osism/templates/osism-netplan.yaml.j2
+++ b/elements/osism-ipa/static/opt/osism/templates/osism-netplan.yaml.j2
@@ -5,6 +5,7 @@ network:
   version: 2
   renderer: networkd
 
+{% if variant == 'BGP' %}
   dummy-devices:
     loopback0:
         addresses:
@@ -17,3 +18,13 @@ network:
         mtu: 9000
         optional: yes
 {% endfor %}
+
+{% elif variant == 'OOB' %}
+  ethernets:
+    eno1:
+        mtu: 1500
+        match:
+            name: eno*
+        addresses:
+        - {{ osism_ipv6 }}/64
+{% endif %}

--- a/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
+++ b/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
@@ -151,9 +151,9 @@ def prepare_config():
     return data
 
 
-def main():
+def run_variant(variant, max_retries = 2):
     attempt = 0
-    max_retries = 2
+    print(f"Trying variant {variant}")
 
     # Sometimes network interfaces are not immediately visible. Therefore, if the
     # Metalbox cannot be reached, the configuration is regenerated once to add any
@@ -161,6 +161,7 @@ def main():
     while attempt <= max_retries:
         print("Before prepare_config()")
         data = prepare_config()
+        data['variant'] = variant
 
         print("Before write_config_files()")
         write_config_files(data)
@@ -175,11 +176,24 @@ def main():
             reachable = check_availability_of_metalbox()
 
         if reachable:
-            break
+            return True
 
         attempt += 1
+    
+    print(f"Variant {variant} failed after {attempt} attempts")
+    return False
+
+def main():
+    # Try multiple variants.
+    # OOB: add osism_ipv6 as a /64 network on the onboard eno* interface
+    # BGP: announce osism_ipv6 as single address via BGP
+    variants = ['BGP', 'OOB']
+    for variant in variants:
+        reachable = run_variant(variant)
+        if reachable:
+            break
     else:
-        raise RuntimeError(f"Failed to reach metalbox after {max_retries} attempts")
+        raise RuntimeError(f"Failed to reach metalbox after trying all variants")
 
     print("Before sync_time_with_metalbox()")
     sync_time_with_metalbox()

--- a/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
+++ b/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
@@ -42,6 +42,23 @@ def scan_interfaces():
 
     return interfaces
 
+def get_onboard_interface(interfaces):
+    # Try to guess lowest onboard interface
+    if_names = [interface[0] for interface in interfaces].sort()
+    for if_name in if_names:
+        if if_name.startswith('eno'):
+            return if_name
+    return if_names[0]
+
+def get_variant():
+    with open("/proc/cmdline", "r") as f:
+        cmdline = f.read().strip()
+    params = (cmdline.strip().split())
+    
+    for param in params:
+        if param.lower().startswith('osism-ipa-network='):
+            return param.split('=')[1].strip().upper()
+    return 'BGP'
 
 config_files = [
     ("frr.conf.j2", "/etc/frr/frr.conf"),
@@ -136,7 +153,9 @@ def prepare_config():
         try:
             interfaces = scan_interfaces()
             data["osism_interfaces"] = [interface[0] for interface in interfaces]
+            data["osism_onboard_interface"] = get_onboard_interface(interfaces)
             data["osism_ipv6"] = "fd33:fd0e:2aee:0:%s" % interfaces[0][1]
+            data["variant"] = get_variant()
             break
         except IndexError:
             attempt += 1
@@ -151,9 +170,9 @@ def prepare_config():
     return data
 
 
-def run_variant(variant, max_retries = 2):
+def main():
     attempt = 0
-    print(f"Trying variant {variant}")
+    max_retries = 2
 
     # Sometimes network interfaces are not immediately visible. Therefore, if the
     # Metalbox cannot be reached, the configuration is regenerated once to add any
@@ -161,7 +180,6 @@ def run_variant(variant, max_retries = 2):
     while attempt <= max_retries:
         print("Before prepare_config()")
         data = prepare_config()
-        data['variant'] = variant
 
         print("Before write_config_files()")
         write_config_files(data)
@@ -176,24 +194,11 @@ def run_variant(variant, max_retries = 2):
             reachable = check_availability_of_metalbox()
 
         if reachable:
-            return True
+            break
 
         attempt += 1
-    
-    print(f"Variant {variant} failed after {attempt} attempts")
-    return False
-
-def main():
-    # Try multiple variants.
-    # OOB: add osism_ipv6 as a /64 network on the onboard eno* interface
-    # BGP: announce osism_ipv6 as single address via BGP
-    variants = ['BGP', 'OOB']
-    for variant in variants:
-        reachable = run_variant(variant)
-        if reachable:
-            break
     else:
-        raise RuntimeError(f"Failed to reach metalbox after trying all variants")
+        raise RuntimeError(f"Failed to reach metalbox after {max_retries} attempts")
 
     print("Before sync_time_with_metalbox()")
     sync_time_with_metalbox()

--- a/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
+++ b/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
@@ -44,7 +44,8 @@ def scan_interfaces():
 
 def get_onboard_interface(interfaces):
     # Try to guess lowest onboard interface
-    if_names = [interface[0] for interface in interfaces].sort()
+    if_names = [interface[0] for interface in interfaces]
+    if_names.sort()
     for if_name in if_names:
         if if_name.startswith('eno'):
             return if_name

--- a/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
+++ b/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
@@ -42,24 +42,27 @@ def scan_interfaces():
 
     return interfaces
 
+
 def get_onboard_interface(interfaces):
     # Try to guess lowest onboard interface
     if_names = [interface[0] for interface in interfaces]
     if_names.sort()
     for if_name in if_names:
-        if if_name.startswith('eno'):
+        if if_name.startswith("eno"):
             return if_name
     return if_names[0]
+
 
 def get_variant():
     with open("/proc/cmdline", "r") as f:
         cmdline = f.read().strip()
-    params = (cmdline.strip().split())
-    
+    params = cmdline.strip().split()
+
     for param in params:
-        if param.lower().startswith('osism-ipa-network='):
-            return param.split('=')[1].strip().upper()
-    return 'BGP'
+        if param.lower().startswith("osism-ipa-network="):
+            return param.split("=")[1].strip().upper()
+    return "BGP"
+
 
 config_files = [
     ("frr.conf.j2", "/etc/frr/frr.conf"),


### PR DESCRIPTION
Reach the metalbox from the IPA image via the shared OOB port, which is a common feature amongst OCP servers. This removed the need for us to connect the metalbox to the main BGP fabric.

Please note that I have not yet tested this.

Fixes https://github.com/osism/openstack-ironic-images/issues/114