### PR TITLE
osism-node: remove all repositories

### DIFF
--- a/elements/osism-node/finalise.d/60-grub
+++ b/elements/osism-node/finalise.d/60-grub
@@ -17,3 +17,6 @@ rm -f /etc/default/grub.d/50-cloudimg-settings.cfg
 update-grub
 grub-install --no-nvram --modules=mdraid1x -v $EFI_BOOT_DIR
 rm -rf /boot/efi/EFI/BOOT
+
+rm -f /etc/apt/sources.list.d/*
+rm -rf /var/lib/apt/lists/*

--- a/elements/osism-node/install.d/40-ansible-install
+++ b/elements/osism-node/install.d/40-ansible-install
@@ -26,3 +26,4 @@ update-initramfs -u
 
 rm -f /etc/netplan/50-cloud-init.yaml
 rm -rf /root/.ansible
+rm -rf /var/tmp/*


### PR DESCRIPTION
We do not know where the image will be used. Either way, all repositories will return during the bootstrap.