### PR TITLE
metalbox: add more packages

### DIFF
--- a/elements/metalbox/static/root/part1.yml
+++ b/elements/metalbox/static/root/part1.yml
@@ -63,8 +63,10 @@
     # packages
     required_packages_extra:
       - ca-certificates
+      - fio
       - frr
       - htop
+      - iperf3
       - ipmitool
       - iptables
       - net-tools


### PR DESCRIPTION
Both fio and iperf3 are useful when testing the performance of a setup, include them by default.