### PR TITLE
metalbox: remove loopback0 device

### DIFF
--- a/elements/metalbox/static/root/part2.yml
+++ b/elements/metalbox/static/root/part2.yml
@@ -7,9 +7,6 @@
   vars:
     network_ethernets: {}
     network_dummy_devices:
-      loopback0:
-        link-local:
-          - ipv6
       metalbox:
         addresses:
           - 192.168.42.10/24


### PR DESCRIPTION
The device is not required during initial boot and is added during deployment of the Metalbox if it is configured in the NetBox.

Part of osism/metalbox#255