### PR TITLE
metalbox: Let registry listen on all addresses

### DIFF
--- a/elements/metalbox/static/usr/local/bin/run.sh
+++ b/elements/metalbox/static/usr/local/bin/run.sh
@@ -8,4 +8,4 @@ if [[ -e /opt/registry.tar.bz2 ]]; then
     docker run --rm -v registry:/volume -v /opt:/import library/alpine:3 sh -c 'cd /volume && tar xjf /import/registry.tar.bz2'
 fi
 
-docker run -d -p 127.0.0.1:5001:5000 -v registry:/var/lib/registry --name registry --restart always library/registry:3
+docker run -d -p 0.0.0.0:5001:5000 -v registry:/var/lib/registry --name registry --restart always library/registry:3


### PR DESCRIPTION
In environments were the metalbox is used as container registry, it needs to be externally accessible.