### PR TITLE
Add nfs client to metalbox image

### DIFF
--- a/elements/metalbox/static/root/part1.yml
+++ b/elements/metalbox/static/root/part1.yml
@@ -70,6 +70,7 @@
       - ipmitool
       - iptables
       - net-tools
+      - nfs-common
       - python3-netaddr
       - rsync
       - skopeo


### PR DESCRIPTION
NFS is somtetimes used in out-of-band networks to provide virtual media to BMCs. An NFS client is added to the metalbox image to connect to these shares for debugging or management purposes.