### PR TITLE
metalbox: Remove GRUB cloudimg-settings.cfg

### DIFF
--- a/elements/metalbox/finalise.d/60-grub
+++ b/elements/metalbox/finalise.d/60-grub
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ ${DIB_DEBUG_TRACE:-0} -gt 0 ]; then
+    set -x
+fi
+
+set -eu
+set -o pipefail
+
+rm -f /etc/default/grub.d/50-cloudimg-settings.cfg
+update-grub


### PR DESCRIPTION
Remove the override for GRUB which resets the `console` setting to a value not specifying the serial TTY's speed.