### PR TITLE
Use HWE kernel in node and metalbox images again

### DIFF
--- a/elements/metalbox/static/root/part1.yml
+++ b/elements/metalbox/static/root/part1.yml
@@ -69,6 +69,7 @@
       - iperf3
       - ipmitool
       - iptables
+      - linux-generic-hwe-24.04
       - net-tools
       - nfs-common
       - python3-netaddr

--- a/elements/osism-node/static/root/part1.yml
+++ b/elements/osism-node/static/root/part1.yml
@@ -28,6 +28,7 @@
       - iperf3
       - ipmitool
       - iptables
+      - linux-generic-hwe-24.04
       - net-tools
       - python3-netaddr
       - rsync


### PR DESCRIPTION
Ubuntu HWE kernel 6.17 has been released in updates and security. The underlying issue was not reproducable in kernels newer than 6.15.8 ([1]).

Revert "Do not install HWE kernel in osism-node image"

This reverts commit d989785a710d6028605b13afc9727628fce1bfb6.

Revert "Do not install HWE kernel in metalbox image (#116)"

This reverts commit 1294dba91831759458bd0ce9f816a31b5274bf76.

[1]
https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2119626