### PR TITLE
Pin setuptools<82.0.0

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -80,6 +80,7 @@
       - "^files/burnin.sh"
       - "^files/burnin/.*"
       - "^playbooks/.*"
+      - "^requirements.txt"
 
 - job:
     name: openstack-ironic-images-publish-burnin
@@ -98,6 +99,7 @@
       - "^files/burnin.sh"
       - "^files/burnin/.*"
       - "^playbooks/.*"
+      - "^requirements.txt"
 
 - job:
     name: openstack-ironic-images-build-metalbox
@@ -110,6 +112,7 @@
       - "^files/metalbox.sh"
       - "^files/metalbox/.*"
       - "^playbooks/.*"
+      - "^requirements.txt"
 
 - job:
     name: openstack-ironic-images-publish-metalbox
@@ -128,6 +131,7 @@
       - "^files/metalbox.sh"
       - "^files/metalbox/.*"
       - "^playbooks/.*"
+      - "^requirements.txt"
 
 - job:
     name: openstack-ironic-images-build-osism-ipa
@@ -146,6 +150,7 @@
       - "^elements/osism-ipa/.*"
       - "^files/osism-ipa.yml$"
       - "^playbooks/.*"
+      - "^requirements.txt"
 
 - job:
     name: openstack-ironic-images-publish-osism-ipa
@@ -179,6 +184,7 @@
       - "^elements/osism-ipa/.*"
       - "^files/osism-ipa-stable.yml$"
       - "^playbooks/.*"
+      - "^requirements.txt"
 
 - job:
     name: openstack-ironic-images-publish-osism-ipa-stable
@@ -214,6 +220,7 @@
       - "^elements/osism-node/.*"
       - "^files/osism-node.yml$"
       - "^playbooks/.*"
+      - "^requirements.txt"
 
 - job:
     name: openstack-ironic-images-publish-osism-node
@@ -246,6 +253,7 @@
       - "^elements/osism-esp/.*"
       - "^files/osism-esp.yml$"
       - "^playbooks/.*"
+      - "^requirements.txt"
 
 - job:
     name: openstack-ironic-images-publish-osism-esp
@@ -279,6 +287,7 @@
       - "^elements/osism-vyos/.*"
       - "^files/osism-vyos.yml$"
       - "^playbooks/.*"
+      - "^requirements.txt"
 
 - job:
     name: openstack-ironic-images-publish-osism-vyos

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 diskimage-builder==3.37.0
+setuptools<82.0.0


### PR DESCRIPTION
+ disk-image-create -a amd64 -t raw -o osism-metalbox-image.raw --image-size 10 vm block-device-efi ubuntu bootloader cloud-init cloud-init-nocloud metalbox Traceback (most recent call last):
  File "/tmp/venv/bin/disk-image-create", line 5, in <module> from diskimage_builder.disk_image_create import main File "/tmp/venv/lib/python3.12/site-packages/diskimage_builder/disk_image_create.py", line 19, in <module> import diskimage_builder.paths File "/tmp/venv/lib/python3.12/site-packages/diskimage_builder/paths.py", line 18, in <module> import pkg_resources ModuleNotFoundError: No module named 'pkg_resources'