### PR TITLE
Revert "Pin setuptools<82.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-diskimage-builder==3.37.0
-setuptools<82.0.0
+diskimage-builder==3.40.2


### PR DESCRIPTION
This partially reverts commit ece9a77fd9b7a746a628c88fd2ab17a6e252ea42.

Instead of capping setuptools, switch to the latest release of diskimage-builder.