### PR TITLE
Fix public access for rclone S3 uploads

### DIFF
--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -84,10 +84,11 @@
         chdir: "{{ zuul.project.src_dir }}"
         cmd: |
           export RCLONE_CONFIG_S3_TYPE=s3
-          export RCLONE_CONFIG_S3_PROVIDER=Other
+          export RCLONE_CONFIG_S3_PROVIDER=Ceph
           export RCLONE_CONFIG_S3_ENDPOINT=https://nbg1.your-objectstorage.com
           export RCLONE_CONFIG_S3_ACCESS_KEY_ID={{ s3.S3_ACCESS_KEY | trim }}
           export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY={{ s3.S3_SECRET_KEY | trim }}
+          export RCLONE_CONFIG_S3_ACL=public-read
 
           sha256sum osism-{{ _dib_element }}-image.{{ _image_format }} osism-{{ _dib_element }}-image.{{ _image_format }}.CHECKSUM
 

--- a/playbooks/builder.yml
+++ b/playbooks/builder.yml
@@ -41,10 +41,11 @@
         chdir: "{{ zuul.project.src_dir }}"
         cmd: |
           export RCLONE_CONFIG_S3_TYPE=s3
-          export RCLONE_CONFIG_S3_PROVIDER=Other
+          export RCLONE_CONFIG_S3_PROVIDER=Ceph
           export RCLONE_CONFIG_S3_ENDPOINT=https://nbg1.your-objectstorage.com
           export RCLONE_CONFIG_S3_ACCESS_KEY_ID={{ s3.S3_ACCESS_KEY | trim }}
           export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY={{ s3.S3_SECRET_KEY | trim }}
+          export RCLONE_CONFIG_S3_ACL=public-read
 
           if [[ "{{ _build_name }}" == "osism-esp" ]]; then
               cp {{ _build_name }}.{{ _image_format }}.sha256 {{ _build_name }}.{{ _image_format }}.CHECKSUM


### PR DESCRIPTION
Set ACL to public-read so uploaded images are publicly accessible, matching the previous behavior with mc.