### PR TITLE
osism-ipa: use only link-up interfaces for FRR BGP neighbors

### DIFF
--- a/elements/osism-ipa/static/opt/osism/templates/default/frr.conf.j2
+++ b/elements/osism-ipa/static/opt/osism/templates/default/frr.conf.j2
@@ -8,13 +8,13 @@ router bgp {{ osism_as }}
  no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
  bgp router-id {{ osism_ipv4 }}
-{% for interface in osism_interfaces %}
+{% for interface in osism_interfaces_up %}
  neighbor {{ interface }} interface remote-as external
 {% endfor %}
  !
  address-family ipv4 unicast
   redistribute connected route-map bgp_out
-{% for interface in osism_interfaces %}
+{% for interface in osism_interfaces_up %}
   neighbor {{ interface }} route-map bgp_out out
 {% endfor %}
   maximum-paths 2
@@ -22,7 +22,7 @@ router bgp {{ osism_as }}
  !
  address-family ipv6 unicast
   redistribute connected route-map bgp_out
-{% for interface in osism_interfaces %}
+{% for interface in osism_interfaces_up %}
   neighbor {{ interface }} activate
   neighbor {{ interface }} route-map bgp_out out
 {% endfor %}

--- a/elements/osism-ipa/static/opt/osism/templates/yrzn001/frr.conf.j2
+++ b/elements/osism-ipa/static/opt/osism/templates/yrzn001/frr.conf.j2
@@ -11,7 +11,7 @@ router bgp {{ osism_as }}
  neighbor switches remote-as external
  neighbor switches password {{ osism_aa }}
  neighbor switches timers connect 30
-{% for interface in osism_interfaces %}
+{% for interface in osism_interfaces_up %}
  neighbor {{ interface }} interface peer-group switches
 {% endfor %}
  !

--- a/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
+++ b/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
@@ -38,8 +38,9 @@ def scan_interfaces():
             continue
         mac = mactools.MacAddress(find_attr(link, "IFLA_ADDRESS"))
         eui64 = mac.eui64_suffix
-        print("%s %s %s" % (if_name, mac, eui64))
-        interfaces.append((if_name, eui64))
+        operstate = link.get("state", "down")
+        print("%s %s %s %s" % (if_name, mac, eui64, operstate))
+        interfaces.append((if_name, eui64, operstate))
 
     return interfaces
 
@@ -217,6 +218,9 @@ def prepare_config():
         try:
             interfaces = scan_interfaces()
             data["osism_interfaces"] = [interface[0] for interface in interfaces]
+            data["osism_interfaces_up"] = [
+                interface[0] for interface in interfaces if interface[2] == "up"
+            ]
             data["osism_onboard_interface"] = get_onboard_interface(interfaces)
             data["osism_ipv4"] = get_ipv4()
             data["osism_ipv6"] = get_ipv6(interfaces)


### PR DESCRIPTION
Netplan continues to configure all discovered interfaces, but FRR now only adds interfaces with an active link as BGP neighbors. This avoids BGP sessions on interfaces without connectivity.

AI-assisted: Claude Code