### PR TITLE
osism-ipa: fix service lifecycle and interface operstate detection

### DIFF
--- a/elements/osism-ipa/package-installs.yaml
+++ b/elements/osism-ipa/package-installs.yaml
@@ -19,3 +19,7 @@ python3-venv:
 util-linux-extra:
 vim:
 wget:
+unattended-upgrades:
+  uninstall: true
+update-notifier-common:
+  uninstall: true

--- a/elements/osism-ipa/post-install.d/80-osism
+++ b/elements/osism-ipa/post-install.d/80-osism
@@ -9,11 +9,13 @@ set -o pipefail
 case "$DIB_INIT_SYSTEM" in
     systemd)
         systemctl mask glean@.service glean.service
-        systemctl disable ironic-agent-resolve-config-drive.service
         systemctl disable apparmor.service
-        systemctl enable systemd-udev-settle.service
+        systemctl disable chrony.service
+        systemctl disable frr.service
+        systemctl disable ironic-agent-resolve-config-drive.service
         systemctl disable ironic-python-agent.service
         systemctl enable osism-ipa-config.service
+        systemctl enable systemd-udev-settle.service
         ;;
     *)
         echo "Unsupported init system $DIB_INIT_SYSTEM"

--- a/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
+++ b/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
@@ -38,7 +38,7 @@ def scan_interfaces():
             continue
         mac = mactools.MacAddress(find_attr(link, "IFLA_ADDRESS"))
         eui64 = mac.eui64_suffix
-        operstate = link.get("state", "down")
+        operstate = find_attr(link, "IFLA_OPERSTATE")
         print("%s %s %s %s" % (if_name, mac, eui64, operstate))
         interfaces.append((if_name, eui64, operstate))
 
@@ -146,19 +146,12 @@ def restart_networking():
 
     subprocess.run(["netplan", "apply"], check=True)
 
-    subprocess.run(["systemctl", "restart", "frr.service"], check=True)
+    subprocess.run(["systemctl", "start", "frr.service"], check=True)
 
 
 def sync_time_with_metalbox():
     """Synchronize time with metalbox, ignoring errors and showing warnings if sync fails."""
     try:
-        # Stop chrony service
-        result = subprocess.run(
-            ["systemctl", "stop", "chrony.service"], capture_output=True, text=True
-        )
-        if result.returncode != 0:
-            print(f"Warning: Failed to stop chrony service: {result.stderr.strip()}")
-
         # Sync time with metalbox
         result = subprocess.run(
             ["chronyd", "-q", "server metalbox iburst"], capture_output=True, text=True
@@ -219,7 +212,7 @@ def prepare_config():
             interfaces = scan_interfaces()
             data["osism_interfaces"] = [interface[0] for interface in interfaces]
             data["osism_interfaces_up"] = [
-                interface[0] for interface in interfaces if interface[2] == "up"
+                interface[0] for interface in interfaces if interface[2] == "UP"
             ]
             data["osism_onboard_interface"] = get_onboard_interface(interfaces)
             data["osism_ipv4"] = get_ipv4()


### PR DESCRIPTION
Disable chrony and frr at boot since they are started by the configure script at the appropriate time. Remove unattended-upgrades and update-notifier-common packages. Fix interface operstate detection to use IFLA_OPERSTATE attribute (returns "UP") instead of link state field.