### PR TITLE
osism-ipa: rename template variables to match osism-ipa-* kernel para…

### DIFF
--- a/elements/osism-ipa/static/opt/osism/templates/default/frr.conf.j2
+++ b/elements/osism-ipa/static/opt/osism/templates/default/frr.conf.j2
@@ -4,10 +4,10 @@ hostname osism-ipa
 log syslog informational
 service integrated-vtysh-config
 !
-router bgp {{ osism_as }}
+router bgp {{ osism_ipa_as }}
  no bgp ebgp-requires-policy
  bgp bestpath as-path multipath-relax
- bgp router-id {{ osism_ipv4 }}
+ bgp router-id {{ osism_ipa_ipv4 }}
 {% for interface in osism_interfaces_up %}
  neighbor {{ interface }} interface remote-as external
 {% endfor %}
@@ -34,11 +34,11 @@ route-map bgp_out permit 10
 exit
 !
 route-map RM_SET_SRC4 permit 10
- set src {{ osism_ipv4 }}
+ set src {{ osism_ipa_ipv4 }}
 exit
 !
 route-map RM_SET_SRC6 permit 10
- set src {{ osism_ipv6 }}
+ set src {{ osism_ipa_ipv6 }}
 exit
 !
 ip protocol bgp route-map RM_SET_SRC4

--- a/elements/osism-ipa/static/opt/osism/templates/default/netplan.yaml.j2
+++ b/elements/osism-ipa/static/opt/osism/templates/default/netplan.yaml.j2
@@ -9,8 +9,8 @@ network:
   dummy-devices:
     loopback0:
         addresses:
-        - {{ osism_ipv4 }}/32
-        - {{ osism_ipv6 }}/128
+        - {{ osism_ipa_ipv4 }}/32
+        - {{ osism_ipa_ipv6 }}/128
 
   ethernets:
 {% for interface in osism_interfaces %}
@@ -24,5 +24,5 @@ network:
     {{ osism_onboard_interface }}:
         mtu: 1500
         addresses:
-        - {{ osism_ipv6 }}/64
+        - {{ osism_ipa_ipv6 }}/64
 {% endif %}

--- a/elements/osism-ipa/static/opt/osism/templates/yrzn001/frr.conf.j2
+++ b/elements/osism-ipa/static/opt/osism/templates/yrzn001/frr.conf.j2
@@ -4,8 +4,8 @@ hostname osism-ipa
 no ipv6 forwarding
 service integrated-vtysh-config
 !
-router bgp {{ osism_as }}
- bgp router-id {{ osism_ipv4 }}
+router bgp {{ osism_ipa_as }}
+ bgp router-id {{ osism_ipa_ipv4 }}
  bgp bestpath as-path multipath-relax
  neighbor switches peer-group
  neighbor switches remote-as external
@@ -46,11 +46,11 @@ route-map RM-switches-out permit 100
 exit
 !
 route-map RM_SET_SRC4 permit 10
- set src {{ osism_ipv4 }}
+ set src {{ osism_ipa_ipv4 }}
 exit
 !
 route-map RM_SET_SRC6 permit 10
- set src {{ osism_ipv6 }}
+ set src {{ osism_ipa_ipv6 }}
 exit
 !
 ip protocol bgp route-map RM_SET_SRC4

--- a/elements/osism-ipa/static/opt/osism/templates/yrzn001/netplan.yaml.j2
+++ b/elements/osism-ipa/static/opt/osism/templates/yrzn001/netplan.yaml.j2
@@ -8,8 +8,8 @@ network:
   dummy-devices:
     loopback0:
         addresses:
-        - {{ osism_ipv4 }}/32
-        - {{ osism_ipv6 }}/128
+        - {{ osism_ipa_ipv4 }}/32
+        - {{ osism_ipa_ipv6 }}/128
 
   ethernets:
 {% for interface in osism_interfaces %}

--- a/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
+++ b/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
@@ -215,9 +215,9 @@ def prepare_config():
                 interface[0] for interface in interfaces if interface[2] == "UP"
             ]
             data["osism_onboard_interface"] = get_onboard_interface(interfaces)
-            data["osism_ipv4"] = get_ipv4()
-            data["osism_ipv6"] = get_ipv6(interfaces)
-            data["osism_as"] = get_as(data["osism_ipv4"])
+            data["osism_ipa_ipv4"] = get_ipv4()
+            data["osism_ipa_ipv6"] = get_ipv6(interfaces)
+            data["osism_ipa_as"] = get_as(data["osism_ipa_ipv4"])
             data["variant"] = get_variant()
             data["type"] = get_type()
             for key, value in get_extra_params().items():


### PR DESCRIPTION
…meters

Rename osism_as, osism_ipv4, osism_ipv6 to osism_ipa_as, osism_ipa_ipv4, osism_ipa_ipv6 for consistency with the kernel parameter names (osism-ipa-as, osism-ipa-ipv4, osism-ipa-ipv6).

AI-assisted: Claude Code