### PR TITLE
osism-ipa: use restart instead of start for FRR service

### DIFF
--- a/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
+++ b/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
@@ -146,7 +146,7 @@ def restart_networking():
 
     subprocess.run(["netplan", "apply"], check=True)
 
-    subprocess.run(["systemctl", "start", "frr.service"], check=True)
+    subprocess.run(["systemctl", "restart", "frr.service"], check=True)
 
 
 def sync_time_with_metalbox():


### PR DESCRIPTION
Using systemctl start is a no-op when FRR is already running, which prevents configuration changes from being applied on subsequent iterations. Restart works correctly in both cases: it starts the service if stopped, and restarts it if running.

AI-assisted: Claude Code