### PR TITLE
osism-ipa: re-scan interfaces after netplan apply before generating F…

### DIFF
--- a/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
+++ b/elements/osism-ipa/static/usr/local/sbin/osism-ipa-configure
@@ -174,21 +174,21 @@ def get_extra_params():
     return extra
 
 
-config_files = [
-    ("frr.conf.j2", "/etc/frr/frr.conf"),
-    ("netplan.yaml.j2", "/etc/netplan/01-osism.yaml"),
-]
-
-
-def write_config_files(data, ipa_type="default"):
+def write_netplan_config(data, ipa_type="default"):
     template_path = "/opt/osism/templates/%s" % ipa_type
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(template_path))
-    for template_name, file_name in config_files:
-        template = env.get_template(template_name)
-        template.stream(data).dump(file_name)
+    template = env.get_template("netplan.yaml.j2")
+    template.stream(data).dump("/etc/netplan/01-osism.yaml")
 
 
-def restart_networking(max_retries=3):
+def write_frr_config(data, ipa_type="default"):
+    template_path = "/opt/osism/templates/%s" % ipa_type
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(template_path))
+    template = env.get_template("frr.conf.j2")
+    template.stream(data).dump("/etc/frr/frr.conf")
+
+
+def apply_netplan(max_retries=3):
     os.chmod("/etc/netplan/01-osism.yaml", stat.S_IRUSR)
 
     subprocess.run(["systemctl", "daemon-reload"], check=True)
@@ -196,7 +196,7 @@ def restart_networking(max_retries=3):
     for attempt in range(1, max_retries + 1):
         result = subprocess.run(["netplan", "apply"], capture_output=True, text=True)
         if result.returncode == 0:
-            break
+            return
         print(
             f"Warning: netplan apply failed (attempt {attempt}/{max_retries}): {result.stderr.strip()}"
         )
@@ -206,12 +206,14 @@ def restart_networking(max_retries=3):
             )
         time.sleep(5 * attempt)
 
+
+def restart_frr(max_retries=3):
     for attempt in range(1, max_retries + 1):
         result = subprocess.run(
             ["systemctl", "restart", "frr.service"], capture_output=True, text=True
         )
         if result.returncode == 0:
-            break
+            return
         print(
             f"Warning: FRR restart failed (attempt {attempt}/{max_retries}): {result.stderr.strip()}"
         )
@@ -282,42 +284,42 @@ def check_availability_of_metalbox(timeout=60):
     return reachable
 
 
-def prepare_config():
-    data = {}
-
-    print("Before scan_interfaces()")
-
-    attempt = 0
-    max_retries = 5
-    while attempt < max_retries:
+def scan_interfaces_with_retry(max_retries=5):
+    for attempt in range(1, max_retries + 1):
         try:
             interfaces = scan_interfaces()
-            data["osism_interfaces"] = [interface[0] for interface in interfaces]
-            data["osism_interfaces_up"] = [
-                interface[0] for interface in interfaces if interface[2] == "UP"
-            ]
-            data["osism_onboard_interface"] = get_onboard_interface(interfaces)
-            data["osism_ipa_ipv4"] = get_ipv4()
-            data["osism_ipa_ipv6"] = get_ipv6(interfaces)
-            data["osism_ipa_as"] = get_as(data["osism_ipa_ipv4"])
-            data["osism_ipa_mtu"] = get_mtu()
-            data["osism_ipa_metalbox_timeout"] = get_metalbox_timeout()
-            data["variant"] = get_variant()
-            data["type"] = get_type()
-            for key, value in get_extra_params().items():
-                if key not in data:
-                    data[key] = value
-            break
+            if interfaces:
+                return interfaces
         except IndexError:
-            attempt += 1
-            if attempt < max_retries:
-                print(
-                    f"Network interfaces not yet correctly available. Attempt {attempt}/{max_retries}. Try again in 20 seconds."
-                )
-                time.sleep(20)
-            else:
-                raise
+            pass
+        if attempt < max_retries:
+            print(
+                f"Network interfaces not yet correctly available. Attempt {attempt}/{max_retries}. Try again in 20 seconds."
+            )
+            time.sleep(20)
+        else:
+            raise RuntimeError(
+                f"No network interfaces found after {max_retries} attempts"
+            )
 
+
+def build_data(interfaces):
+    data = {}
+    data["osism_interfaces"] = [interface[0] for interface in interfaces]
+    data["osism_interfaces_up"] = [
+        interface[0] for interface in interfaces if interface[2] == "UP"
+    ]
+    data["osism_onboard_interface"] = get_onboard_interface(interfaces)
+    data["osism_ipa_ipv4"] = get_ipv4()
+    data["osism_ipa_ipv6"] = get_ipv6(interfaces)
+    data["osism_ipa_as"] = get_as(data["osism_ipa_ipv4"])
+    data["osism_ipa_mtu"] = get_mtu()
+    data["osism_ipa_metalbox_timeout"] = get_metalbox_timeout()
+    data["variant"] = get_variant()
+    data["type"] = get_type()
+    for key, value in get_extra_params().items():
+        if key not in data:
+            data[key] = value
     return data
 
 
@@ -327,25 +329,40 @@ def main():
         print("Configuring metalbox IP: %s" % metalbox_ip)
         update_hosts_metalbox(metalbox_ip)
 
-    attempt = 0
-    max_retries = 2
+    max_retries = 3
 
-    # Sometimes network interfaces are not immediately visible. Therefore, if the
-    # Metalbox cannot be reached, the configuration is regenerated once to add any
-    # network interfaces that may be added later.
-    while attempt <= max_retries:
-        print("Before prepare_config()")
-        data = prepare_config()
+    for attempt in range(1, max_retries + 1):
+        # Step 1: Scan interfaces and generate/apply netplan config
+        print("Scanning interfaces (attempt %d/%d)" % (attempt, max_retries))
+        interfaces = scan_interfaces_with_retry()
+        data = build_data(interfaces)
 
-        print("Before write_config_files()")
-        write_config_files(data, data["type"])
+        print("Writing netplan config")
+        write_netplan_config(data, data["type"])
 
-        print("Before restart_networking()")
-        restart_networking()
+        print("Applying netplan config")
+        apply_netplan()
 
-        print("Before check_availability_of_metalbox()")
+        # Wait for interfaces to come up after netplan apply
+        print("Waiting for interfaces to settle")
+        time.sleep(10)
+
+        # Step 2: Scan interfaces again (now with correct link states)
+        print("Re-scanning interfaces after netplan apply")
+        interfaces = scan_interfaces_with_retry()
+        data = build_data(interfaces)
+
+        # Step 3: Generate FRR config and restart FRR
+        print("Writing FRR config")
+        write_frr_config(data, data["type"])
+
+        print("Restarting FRR")
+        restart_frr()
+
+        # Step 4: Check if metalbox is reachable
+        print("Checking availability of metalbox")
         timeout = data["osism_ipa_metalbox_timeout"]
-        if attempt > 0:
+        if attempt > 1:
             reachable = check_availability_of_metalbox(timeout * 2)
         else:
             reachable = check_availability_of_metalbox(timeout)
@@ -353,7 +370,10 @@ def main():
         if reachable:
             break
 
-        attempt += 1
+        print(
+            "Metalbox not reachable (attempt %d/%d), retrying from scratch"
+            % (attempt, max_retries)
+        )
     else:
         raise RuntimeError(f"Failed to reach metalbox after {max_retries} attempts")
 


### PR DESCRIPTION
…RR config

Split the configure flow to solve a chicken-and-egg problem: interfaces are not UP until netplan is applied, but FRR config needs correct link states. The new flow is:

1. Scan interfaces → write netplan config → apply netplan → wait
2. Re-scan interfaces (now UP) → write FRR config → restart FRR
3. Check metalbox reachability, retry from step 1 if unreachable

AI-assisted: Claude Code