### PR TITLE
osism-ipa: blacklist bnxt_re kernel module

### DIFF
--- a/elements/osism-ipa/static/etc/modprobe.d/blacklist-bnxt-re.conf
+++ b/elements/osism-ipa/static/etc/modprobe.d/blacklist-bnxt-re.conf
@@ -1,0 +1,3 @@
+# The bnxt_re (Broadcom NetXtreme RoCE/RDMA) module takes a very long
+# time to load and is not needed in the Ironic Python Agent.
+blacklist bnxt_re


### PR DESCRIPTION
The bnxt_re (Broadcom NetXtreme RoCE/RDMA) module takes a very long time to load and is not needed in the Ironic Python Agent.