### PR TITLE
Revert "osism-ipa: pin repo refs to stable/2024.2 branch (#196)"

### DIFF
--- a/files/osism-ipa-stable.yml
+++ b/files/osism-ipa-stable.yml
@@ -20,5 +20,5 @@
     DIB_DEV_USER_AUTHORIZED_KEYS: ./files/dragon-ssh-key.pub
     DIB_OSISM_HOSTNAME: osism-ipa
     DIB_RELEASE: noble
-    DIB_REPOREF_ironic_python_agent: origin/stable/2024.2
-    DIB_REPOREF_requirements: origin/stable/2024.2
+    DIB_REPOREF_ironic_python_agent: origin/stable/2025.1
+    DIB_REPOREF_requirements: origin/stable/2025.1


### PR DESCRIPTION
This reverts commit 978c1b881bd335ef1771ca149303f0ddce32337c.