### PR TITLE
Fix rclone S3 configuration for Ceph provider

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -2,7 +2,7 @@
 - secret:
     name: SECRET_OPENSTACK_IRONIC_IMAGES
     data:
-      S3_ACCESS_KEY: !encrypted/pkcs1-oaep
+      ACCESS_KEY: !encrypted/pkcs1-oaep
         - lCrjjw0PGgYdGd6bhvt8QAIZwOGqrGqQqxNrCLw5QrfcpsMVVibKkqSp35xmorMOJbvQ3
           jWKAJpqfQNL+UEE/e5WZwfe7pRGKDx3u2fKdCkGexSC2Q2vKCKEL6D20OPW7ELsOoh+Si
           8V0UaLqNnROUrbZZlzZcyQ7yUJNscYTcZcQ/DQJZjNLS/nnZWTThizV5+mzYDtVBdmrhn
@@ -13,7 +13,7 @@
           t+aq7j3Wlb5TOrUf7LeEmYQ0jYW898zKnnAYHhPy8w3IYX4DKEZQB1EyCCsTSJLCrVqkJ
           bdvG5/88EUWd3PCQ16YsKC7CzDd+TzWe99oYFSSJ91Km9pItIH3y8SkZLkgTPT91Mf8BK
           ioa8WKFwrBGwJyfFDCQDQ2grieUzfgV1pc3SMcutbKqylM4vsO6h6feIp+eJKQ=
-      S3_SECRET_KEY: !encrypted/pkcs1-oaep
+      SECRET_KEY: !encrypted/pkcs1-oaep
         - SwQdIWGnwIBDIn6Xvmt7xsKXx7/qiNuFNqb61p5mFAQOzKdJO3voMRBM40lX9oawgclsh
           pcLfQtsYBVkU3XoacoChsEKgmJ/qqHLJghwzPeBpVMakwyPx7DQDYEWaEYziUgMeGmlEc
           Jgsj3GCFqWZnRbdMob6WEAVWpzsFteS3PvNnSoLveUnN44rLdjrRllmpAp/7hq+TABtgg
@@ -91,7 +91,7 @@
       dib_element: burnin
       image_format: raw
     secrets:
-      - name: s3
+      - name: secret
         secret: SECRET_OPENSTACK_IRONIC_IMAGES
         pass-to-parent: true
     files:
@@ -123,7 +123,7 @@
       dib_element: metalbox
       image_format: raw
     secrets:
-      - name: s3
+      - name: secret
         secret: SECRET_OPENSTACK_IRONIC_IMAGES
         pass-to-parent: true
     files:
@@ -162,7 +162,7 @@
       image_format: initramfs
       upload_image: true
     secrets:
-      - name: s3
+      - name: secret
         secret: SECRET_OPENSTACK_IRONIC_IMAGES
         pass-to-parent: true
     files: *osism_ipa_files
@@ -196,7 +196,7 @@
       image_format: initramfs
       upload_image: true
     secrets:
-      - name: s3
+      - name: secret
         secret: SECRET_OPENSTACK_IRONIC_IMAGES
         pass-to-parent: true
     files: *osism_ipa_stable_files
@@ -231,7 +231,7 @@
       build_name: osism-node
       upload_image: true
     secrets:
-      - name: s3
+      - name: secret
         secret: SECRET_OPENSTACK_IRONIC_IMAGES
         pass-to-parent: true
     files: *osism_node_files
@@ -265,7 +265,7 @@
       image_format: raw
       upload_image: true
     secrets:
-      - name: s3
+      - name: secret
         secret: SECRET_OPENSTACK_IRONIC_IMAGES
         pass-to-parent: true
     files: *osism_esp_files
@@ -298,7 +298,7 @@
       build_name: osism-vyos
       upload_image: true
     secrets:
-      - name: s3
+      - name: secret
         secret: SECRET_OPENSTACK_IRONIC_IMAGES
         pass-to-parent: true
     files: *osism_vyos_files

--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -83,12 +83,6 @@
         executable: /bin/bash
         chdir: "{{ zuul.project.src_dir }}"
         cmd: |
-          export RCLONE_CONFIG_S3_TYPE=s3
-          export RCLONE_CONFIG_S3_PROVIDER=Other
-          export RCLONE_CONFIG_S3_ENDPOINT=https://nbg1.your-objectstorage.com
-          export RCLONE_CONFIG_S3_ACCESS_KEY_ID={{ s3.S3_ACCESS_KEY | trim }}
-          export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY={{ s3.S3_SECRET_KEY | trim }}
-
           sha256sum osism-{{ _dib_element }}-image.{{ _image_format }} osism-{{ _dib_element }}-image.{{ _image_format }}.CHECKSUM
 
           if [[ "{{ _image_format }}" == "raw" ]]; then
@@ -99,6 +93,15 @@
               rclone copyto osism-{{ _dib_element }}-image.{{ _image_format }} s3:osism/openstack-ironic-images/osism-{{ _dib_element }}-image.{{ _image_format }}
           fi
 
+      environment:
+        RCLONE_CONFIG_S3_TYPE: s3
+        RCLONE_CONFIG_S3_PROVIDER: Ceph
+        RCLONE_CONFIG_S3_ENDPOINT: https://nbg1.your-objectstorage.com
+        RCLONE_CONFIG_S3_REGION: nbg1
+        RCLONE_CONFIG_S3_ACCESS_KEY_ID: "{{ secret.ACCESS_KEY | trim }}"
+        RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "{{ secret.SECRET_KEY | trim }}"
+        RCLONE_CONFIG_S3_ACL: public-read
+        RCLONE_CONFIG_S3_NO_CHECK_BUCKET: "true"
       when: upload_image | bool
       no_log: true
       changed_when: true

--- a/playbooks/builder.yml
+++ b/playbooks/builder.yml
@@ -40,12 +40,6 @@
         executable: /bin/bash
         chdir: "{{ zuul.project.src_dir }}"
         cmd: |
-          export RCLONE_CONFIG_S3_TYPE=s3
-          export RCLONE_CONFIG_S3_PROVIDER=Other
-          export RCLONE_CONFIG_S3_ENDPOINT=https://nbg1.your-objectstorage.com
-          export RCLONE_CONFIG_S3_ACCESS_KEY_ID={{ s3.S3_ACCESS_KEY | trim }}
-          export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY={{ s3.S3_SECRET_KEY | trim }}
-
           if [[ "{{ _build_name }}" == "osism-esp" ]]; then
               cp {{ _build_name }}.{{ _image_format }}.sha256 {{ _build_name }}.{{ _image_format }}.CHECKSUM
               rclone copyto {{ _build_name }}.{{ _image_format }} s3:osism/openstack-ironic-images/{{ _build_name }}.{{ _image_format }}
@@ -65,6 +59,15 @@
               rclone copyto {{ _build_name }}.{{ _image_format }} s3:osism/openstack-ironic-images/{{ _build_name }}.{{ _image_format }}
           fi
 
+      environment:
+        RCLONE_CONFIG_S3_TYPE: s3
+        RCLONE_CONFIG_S3_PROVIDER: Ceph
+        RCLONE_CONFIG_S3_ENDPOINT: https://nbg1.your-objectstorage.com
+        RCLONE_CONFIG_S3_REGION: nbg1
+        RCLONE_CONFIG_S3_ACCESS_KEY_ID: "{{ secret.ACCESS_KEY | trim }}"
+        RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "{{ secret.SECRET_KEY | trim }}"
+        RCLONE_CONFIG_S3_ACL: public-read
+        RCLONE_CONFIG_S3_NO_CHECK_BUCKET: "true"
       when: upload_image | bool
       no_log: true
       changed_when: true


### PR DESCRIPTION
Move rclone config from inline shell exports to Ansible environment block, switch provider to Ceph, add region/ACL/no-check-bucket settings, and rename secret references from s3.S3_ACCESS_KEY to secret.ACCESS_KEY.

AI-assisted: Claude Code