### PR TITLE
metalbox: version CI jobs for 2024.2 and 2025.1

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -30,7 +30,11 @@
     max: 1
 
 - semaphore:
-    name: semaphore-openstack-ironic-images-publish-metalbox
+    name: semaphore-openstack-ironic-images-publish-metalbox-2024.2
+    max: 1
+
+- semaphore:
+    name: semaphore-openstack-ironic-images-publish-metalbox-2025.1
     max: 1
 
 - semaphore:
@@ -102,11 +106,12 @@
       - "^requirements.txt"
 
 - job:
-    name: openstack-ironic-images-build-metalbox
+    name: openstack-ironic-images-build-metalbox-2024.2
     parent: abstract-openstack-ironic-images-build
     vars:
       dib_element: metalbox
       image_format: raw
+      openstack_version: 2024.2
     files:
       - "^elements/metalbox/.*"
       - "^files/metalbox.sh"
@@ -115,13 +120,48 @@
       - "^requirements.txt"
 
 - job:
-    name: openstack-ironic-images-publish-metalbox
+    name: openstack-ironic-images-publish-metalbox-2024.2
     parent: abstract-openstack-ironic-images-publish
     semaphores:
-      - name: semaphore-openstack-ironic-images-publish-metalbox
+      - name: semaphore-openstack-ironic-images-publish-metalbox-2024.2
     vars:
       dib_element: metalbox
       image_format: raw
+      openstack_version: 2024.2
+    secrets:
+      - name: secret
+        secret: SECRET_OPENSTACK_IRONIC_IMAGES
+        pass-to-parent: true
+    files:
+      - "^elements/metalbox/.*"
+      - "^files/metalbox.sh"
+      - "^files/metalbox/.*"
+      - "^playbooks/.*"
+      - "^requirements.txt"
+
+- job:
+    name: openstack-ironic-images-build-metalbox-2025.1
+    parent: abstract-openstack-ironic-images-build
+    vars:
+      dib_element: metalbox
+      image_format: raw
+      openstack_version: 2025.1
+    files:
+      - "^elements/metalbox/.*"
+      - "^files/metalbox.sh"
+      - "^files/metalbox/.*"
+      - "^playbooks/.*"
+      - "^requirements.txt"
+
+- job:
+    name: openstack-ironic-images-publish-metalbox-2025.1
+    parent: abstract-openstack-ironic-images-publish
+    semaphores:
+      - name: semaphore-openstack-ironic-images-publish-metalbox-2025.1
+    vars:
+      dib_element: metalbox
+      image_format: raw
+      openstack_version: 2025.1
     secrets:
       - name: secret
         secret: SECRET_OPENSTACK_IRONIC_IMAGES
@@ -309,7 +349,8 @@
     check:
       jobs:
         - openstack-ironic-images-build-burnin
-        - openstack-ironic-images-build-metalbox
+        - openstack-ironic-images-build-metalbox-2024.2
+        - openstack-ironic-images-build-metalbox-2025.1
         - openstack-ironic-images-build-osism-ipa
         - openstack-ironic-images-build-osism-ipa-stable
         - openstack-ironic-images-build-osism-node
@@ -318,7 +359,8 @@
         - yamllint
     periodic-daily:
       jobs:
-        - openstack-ironic-images-publish-metalbox
+        - openstack-ironic-images-publish-metalbox-2024.2
+        - openstack-ironic-images-publish-metalbox-2025.1
         - yamllint
     periodic-weekly:
       jobs:
@@ -331,7 +373,9 @@
       jobs:
         - openstack-ironic-images-publish-burnin:
             branches: main
-        - openstack-ironic-images-publish-metalbox:
+        - openstack-ironic-images-publish-metalbox-2024.2:
+            branches: main
+        - openstack-ironic-images-publish-metalbox-2025.1:
             branches: main
         - openstack-ironic-images-publish-osism-ipa:
             branches: main

--- a/playbooks/build.yml
+++ b/playbooks/build.yml
@@ -5,9 +5,11 @@
   vars:
     _dib_element: "{{ dib_element | default('burnin') }}"
     _image_format: "{{ image_format | default('raw') }}"
+    _openstack_version: "{{ openstack_version | default('2024.2') }}"
+    _image_name: "osism-{{ _dib_element }}{{ '-' + _openstack_version if openstack_version is defined else '' }}-image"
 
   tasks:
-    - name: Check registry.tar.bz2 timestamp for metalbox image
+    - name: Check registry tarball timestamp for metalbox image
       ansible.builtin.shell:
         executable: /bin/bash
         cmd: |
@@ -15,7 +17,7 @@
 
           MAX_ATTEMPTS=12
           WAIT_SECONDS=300
-          URL="https://nbg1.your-objectstorage.com/osism/metalbox/registry.tar.bz2"
+          URL="https://nbg1.your-objectstorage.com/osism/metalbox/registry-{{ _openstack_version }}.tar.bz2"
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
             echo "Attempt $attempt of $MAX_ATTEMPTS: Checking Last-Modified header..."
@@ -72,7 +74,7 @@
           disk-image-create \
             -a amd64 \
             -t {{ _image_format }} \
-            -o osism-{{ _dib_element }}-image.{{ _image_format }} \
+            -o {{ _image_name }}.{{ _image_format }} \
             --image-size $IMAGE_SIZE \
             vm block-device-efi ubuntu bootloader cloud-init $IMAGE_ELEMENTS {{ _dib_element }}
 
@@ -83,14 +85,14 @@
         executable: /bin/bash
         chdir: "{{ zuul.project.src_dir }}"
         cmd: |
-          sha256sum osism-{{ _dib_element }}-image.{{ _image_format }} osism-{{ _dib_element }}-image.{{ _image_format }}.CHECKSUM
+          sha256sum {{ _image_name }}.{{ _image_format }} {{ _image_name }}.{{ _image_format }}.CHECKSUM
 
           if [[ "{{ _image_format }}" == "raw" ]]; then
-              zip osism-{{ _dib_element }}-image.zip osism-{{ _dib_element }}-image.{{ _image_format }} osism-{{ _dib_element }}-image.{{ _image_format }}.CHECKSUM
-              rclone copyto osism-{{ _dib_element }}-image.zip s3:osism/openstack-ironic-images/osism-{{ _dib_element }}-image.zip
+              zip {{ _image_name }}.zip {{ _image_name }}.{{ _image_format }} {{ _image_name }}.{{ _image_format }}.CHECKSUM
+              rclone copyto {{ _image_name }}.zip s3:osism/openstack-ironic-images/{{ _image_name }}.zip
           else
-              rclone copyto osism-{{ _dib_element }}-image.{{ _image_format }}.CHECKSUM s3:osism/openstack-ironic-images/osism-{{ _dib_element }}-image.{{ _image_format }}.CHECKSUM
-              rclone copyto osism-{{ _dib_element }}-image.{{ _image_format }} s3:osism/openstack-ironic-images/osism-{{ _dib_element }}-image.{{ _image_format }}
+              rclone copyto {{ _image_name }}.{{ _image_format }}.CHECKSUM s3:osism/openstack-ironic-images/{{ _image_name }}.{{ _image_format }}.CHECKSUM
+              rclone copyto {{ _image_name }}.{{ _image_format }} s3:osism/openstack-ironic-images/{{ _image_name }}.{{ _image_format }}
           fi
 
       environment:


### PR DESCRIPTION
Split the single metalbox build/publish jobs into per-OpenStack-version variants (2024.2 and 2025.1), each with its own semaphore, and update the build playbook to use a versioned registry tarball URL.