### PR TITLE
metalbox: log image catalog from registry.tar.bz2 during build

### DIFF
--- a/elements/metalbox/install.d/40-install
+++ b/elements/metalbox/install.d/40-install
@@ -71,6 +71,12 @@ skopeo copy --dest-tls-verify=false docker://registry.osism.tech/dockerhub/libra
 
 if [[ "$DIB_METALBOX_DOWNLOAD_REGISTRY_ARCHIVE" == "true" ]] then
     wget -O /opt/registry.tar.bz2 https://nbg1.your-objectstorage.com/osism/metalbox/registry.tar.bz2
+
+    echo "===== registry.tar.bz2 image catalog ====="
+    tar tjf /opt/registry.tar.bz2 \
+        | sed -n 's|.*repositories/\(.*\)/_manifests/tags/\([^/]*\)/current/link$|\1:\2|p' \
+        | sort -u
+    echo "===== end registry.tar.bz2 image catalog ====="
 fi
 
 # download ironic images


### PR DESCRIPTION
Parses the Docker Registry v2 on-disk layout directly out of the archive index (tar tjf, no extraction, no running registry) and prints repo:tag pairs to the build log, right after the archive is downloaded.

AI-assisted: Claude Code