### PR TITLE
metalbox: add retry to tarball download

### DIFF
--- a/elements/metalbox/install.d/40-install
+++ b/elements/metalbox/install.d/40-install
@@ -82,8 +82,10 @@ fi
 # download ironic images
 
 if [[ "$DIB_METALBOX_IPA_IMAGES" == "true" ]] then
-    wget -O /opt/ironic-agent.initramfs https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-${DIB_METALBOX_OPENSTACK_RELEASE}.initramfs
-    wget -O /opt/ironic-agent.kernel https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-${DIB_METALBOX_OPENSTACK_RELEASE}.kernel
+    ping -c2 tarballs.opendev.org
+
+    wget --tries=3 -O /opt/ironic-agent.initramfs https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-${DIB_METALBOX_OPENSTACK_RELEASE}.initramfs || exit 2
+    wget --tries=3 -O /opt/ironic-agent.kernel https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-${DIB_METALBOX_OPENSTACK_RELEASE}.kernel || exit 2
 fi
 
 log_disk_usage "after metalbox downloads"


### PR DESCRIPTION
Sometimes downloads fail on the first attempt, add some retries and fail fast if the download still is failing. Also add a ping before starting downloads to help with DNS resolution.

AI-assisted: Claude Code