### PR TITLE
Explicitly label ESP filesystem

### DIFF
--- a/elements/block-device-osism-efi/block-device-default.yaml
+++ b/elements/block-device-osism-efi/block-device-default.yaml
@@ -10,6 +10,7 @@
         type: 'EF00'
         size: 549MiB
         mkfs:
+          label: ESP
           type: vfat
           mount:
             mount_point: /boot/efi


### PR DESCRIPTION
If the ESP filesystem is not labeled explicitly it will be taken from the nodes name, which, if not given, consists of the nodes key and its base name ([1]). Therefore without an explicit label the ESP filesystem is labeled `MKFS_ESP`. This leads to errors during node boot, because an ESP with that label is not found.

[1]
https://opendev.org/openstack/diskimage-builder/src/branch/master/diskimage_builder/block_device/config.py#L71