### PR TITLE
metalbox: make DNS warmup ping non-fatal

### DIFF
--- a/elements/metalbox/install.d/40-install
+++ b/elements/metalbox/install.d/40-install
@@ -82,7 +82,7 @@ fi
 # download ironic images
 
 if [[ "$DIB_METALBOX_IPA_IMAGES" == "true" ]] then
-    ping -c2 tarballs.opendev.org
+    ping -c2 tarballs.opendev.org || true
 
     wget --tries=3 -O /opt/ironic-agent.initramfs https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-${DIB_METALBOX_OPENSTACK_RELEASE}.initramfs || exit 2
     wget --tries=3 -O /opt/ironic-agent.kernel https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-${DIB_METALBOX_OPENSTACK_RELEASE}.kernel || exit 2


### PR DESCRIPTION
Allow the tarballs.opendev.org ping to fail without aborting the build; it serves only as a DNS warmup, while the subsequent wget calls remain authoritative for download success.

AI-assisted: Claude Code