### PR TITLE
metalbox: make IPA tarball downloads non-fatal

### DIFF
--- a/elements/metalbox/install.d/40-install
+++ b/elements/metalbox/install.d/40-install
@@ -84,8 +84,8 @@ fi
 if [[ "$DIB_METALBOX_IPA_IMAGES" == "true" ]] then
     ping -c2 tarballs.opendev.org || true
 
-    wget --tries=3 -O /opt/ironic-agent.initramfs https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-${DIB_METALBOX_OPENSTACK_RELEASE}.initramfs || exit 2
-    wget --tries=3 -O /opt/ironic-agent.kernel https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-${DIB_METALBOX_OPENSTACK_RELEASE}.kernel || exit 2
+    wget --tries=3 -O /opt/ironic-agent.initramfs https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-${DIB_METALBOX_OPENSTACK_RELEASE}.initramfs || rm -f /opt/ironic-agent.initramfs
+    wget --tries=3 -O /opt/ironic-agent.kernel https://tarballs.opendev.org/openstack/ironic-python-agent/dib/files/ipa-centos9-stable-${DIB_METALBOX_OPENSTACK_RELEASE}.kernel || rm -f /opt/ironic-agent.kernel
 fi
 
 log_disk_usage "after metalbox downloads"


### PR DESCRIPTION
The IPA image can be loaded manually if the download from tarballs.opendev.org fails, so don't abort the build on failure.

AI-assisted: Claude Code