### PR TITLE
Release IPA stable build as osism-ipa

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -38,7 +38,7 @@
     max: 1
 
 - semaphore:
-    name: semaphore-openstack-ironic-images-publish-osism-ipa-stable
+    name: semaphore-openstack-ironic-images-publish-osism-ipa-latest
     max: 1
 
 - semaphore:
@@ -168,7 +168,7 @@
     files: *osism_ipa_files
 
 - job:
-    name: openstack-ironic-images-build-osism-ipa-stable
+    name: openstack-ironic-images-build-osism-ipa-latest
     parent: base-extra-logs
     nodeset:
       nodes:
@@ -177,29 +177,29 @@
     pre-run: playbooks/pre.yml
     run: playbooks/builder.yml
     vars:
-      build_name: osism-ipa-stable
+      build_name: osism-ipa-latest
       upload_image: false
-    files: &osism_ipa_stable_files
+    files: &osism_ipa_latest_files
       - "^elements/install-ansible/.*"
       - "^elements/osism-ipa/.*"
-      - "^files/osism-ipa-stable.yml$"
+      - "^files/osism-ipa-latest.yml$"
       - "^playbooks/.*"
       - "^requirements.txt"
 
 - job:
-    name: openstack-ironic-images-publish-osism-ipa-stable
-    parent: openstack-ironic-images-build-osism-ipa-stable
+    name: openstack-ironic-images-publish-osism-ipa-latest
+    parent: openstack-ironic-images-build-osism-ipa-latest
     semaphores:
-      - name: semaphore-openstack-ironic-images-publish-osism-ipa-stable
+      - name: semaphore-openstack-ironic-images-publish-osism-ipa-latest
     vars:
-      build_name: osism-ipa-stable
+      build_name: osism-ipa-latest
       image_format: initramfs
       upload_image: true
     secrets:
       - name: secret
         secret: SECRET_OPENSTACK_IRONIC_IMAGES
         pass-to-parent: true
-    files: *osism_ipa_stable_files
+    files: *osism_ipa_latest_files
 
 - job:
     name: openstack-ironic-images-build-osism-node
@@ -311,7 +311,7 @@
         - openstack-ironic-images-build-burnin
         - openstack-ironic-images-build-metalbox
         - openstack-ironic-images-build-osism-ipa
-        - openstack-ironic-images-build-osism-ipa-stable
+        - openstack-ironic-images-build-osism-ipa-latest
         - openstack-ironic-images-build-osism-node
         - openstack-ironic-images-build-osism-esp
         - openstack-ironic-images-build-osism-vyos
@@ -325,7 +325,7 @@
         - openstack-ironic-images-publish-burnin
         - openstack-ironic-images-publish-osism-esp
         - openstack-ironic-images-publish-osism-ipa
-        - openstack-ironic-images-publish-osism-ipa-stable
+        - openstack-ironic-images-publish-osism-ipa-latest
         - openstack-ironic-images-publish-osism-node
     post:
       jobs:
@@ -335,7 +335,7 @@
             branches: main
         - openstack-ironic-images-publish-osism-ipa:
             branches: main
-        - openstack-ironic-images-publish-osism-ipa-stable:
+        - openstack-ironic-images-publish-osism-ipa-latest:
             branches: main
         - openstack-ironic-images-publish-osism-node:
             branches: main

--- a/files/osism-ipa-latest.yml
+++ b/files/osism-ipa-latest.yml
@@ -1,9 +1,9 @@
 ---
-- imagename: osism-ipa-stable
+- imagename: osism-ipa-latest
   arch: amd64
   image-size: 5
   checksum: true
-  logfile: /home/zuul/zuul-output/logs/osism-ipa-stable.log
+  logfile: /home/zuul/zuul-output/logs/osism-ipa-latest.log
   elements:
     - ubuntu
     - ironic-python-agent-ramdisk
@@ -20,5 +20,3 @@
     DIB_DEV_USER_AUTHORIZED_KEYS: ./files/dragon-ssh-key.pub
     DIB_OSISM_HOSTNAME: osism-ipa
     DIB_RELEASE: noble
-    DIB_REPOREF_ironic_python_agent: origin/stable/2025.1
-    DIB_REPOREF_requirements: origin/stable/2025.1

--- a/files/osism-ipa.yml
+++ b/files/osism-ipa.yml
@@ -20,3 +20,5 @@
     DIB_DEV_USER_AUTHORIZED_KEYS: ./files/dragon-ssh-key.pub
     DIB_OSISM_HOSTNAME: osism-ipa
     DIB_RELEASE: noble
+    DIB_REPOREF_ironic_python_agent: origin/stable/2025.1
+    DIB_REPOREF_requirements: origin/stable/2025.1


### PR DESCRIPTION
Release IPA stable build as `osism-ipa` and IPA development branch as
`osism-ipa-latest`.
The metalbox currently documents download and uses `osism-ipa`, which
currently contains the build from `IPA` development branch. This will
occationally break things. Instead of reconfiguring metalbox and
documenting transiatory behaviour we release the IPA stable build as
`osism-ipa` and move development to `osism-ipa-latest`.