### PR TITLE
Fix grub error on software RAID

### DIFF
--- a/elements/osism-node/finalise.d/60-grub
+++ b/elements/osism-node/finalise.d/60-grub
@@ -13,6 +13,14 @@ if [ -f /boot/grub/x86_64-efi/mdraid1x.mod ]; then
     cp /boot/grub/x86_64-efi/mdraid1x.mod /boot/efi/$EFI_BOOT_DIR
 fi
 
+# NOTE: Disable `quick_boot`, which gates `recordfail`. The `recordfail`
+# feature relies on being able to write to grubenv, which is not implemented
+# for mdraids. This leads to the grub error
+# "Diskfilter writes are not supported"
+# https://askubuntu.com/questions/468466/diskfilter-writes-are-not-supported-what-triggers-this-error
+# Since this image may end up on an mdraid we disable recordfail here.
+sed -i 's#quick_boot="1"#quick_boot="0"#g' /etc/grub.d/*
+
 rm -f /etc/default/grub.d/50-cloudimg-settings.cfg
 update-grub
 grub-install --no-nvram --modules=mdraid1x -v $EFI_BOOT_DIR


### PR DESCRIPTION
When the `osism-node` image was deployed on software RAID, grub errored with `error:  Diskfilter writes are not supported`. The root cause is that writing `grubenv` is not implemented in grub as layed out in [1].
The grub feature causing the writes to `grubenv` is `recordfail`, which automatically extends the timeout after a failed boot. Since this feature is not essential and fails on software RAIDs it is deactivated by disabling `quick_boot`. Although not recommended by [1], because it supposedly turns off other features aswell, I have only found it to disable `recordfail` after diffing grub configs.

[1]
https://askubuntu.com/questions/468466/diskfilter-writes-are-not-supported-what-triggers-this-error