### PR TITLE
metalbox: retry corrupt registry.tar.bz2 download

### DIFF
--- a/elements/metalbox/install.d/40-install
+++ b/elements/metalbox/install.d/40-install
@@ -69,14 +69,35 @@ skopeo copy --dest-tls-verify=false docker://registry.osism.tech/dockerhub/libra
 
 # download registry volume archive
 
-if [[ "$DIB_METALBOX_DOWNLOAD_REGISTRY_ARCHIVE" == "true" ]] then
-    wget -O /opt/registry.tar.bz2 https://nbg1.your-objectstorage.com/osism/metalbox/registry.tar.bz2
-
-    echo "===== registry.tar.bz2 image catalog ====="
-    tar tjf /opt/registry.tar.bz2 \
-        | sed -n 's|.*repositories/\(.*\)/_manifests/tags/\([^/]*\)/current/link$|\1:\2|p' \
-        | sort -u
-    echo "===== end registry.tar.bz2 image catalog ====="
+if [[ "$DIB_METALBOX_DOWNLOAD_REGISTRY_ARCHIVE" == "true" ]]; then
+    url="https://nbg1.your-objectstorage.com/osism/metalbox/registry.tar.bz2"
+    max_attempts=4
+    attempt=1
+    while true; do
+        echo "Downloading registry.tar.bz2 (attempt ${attempt}/${max_attempts})..."
+        rm -f /opt/registry.tar.bz2
+        # The catalog listing doubles as the integrity gate: tar -j fully
+        # decompresses the stream, so a full-length-but-corrupt download fails
+        # here (non-zero under pipefail) and triggers a clean re-download
+        # instead of poisoning the build. --tries lets wget ride out transient
+        # connection drops to fetch a complete body.
+        if wget --tries=3 --timeout=120 -O /opt/registry.tar.bz2 "$url" \
+           && catalog=$(tar tjf /opt/registry.tar.bz2 \
+                | sed -n 's|.*repositories/\(.*\)/_manifests/tags/\([^/]*\)/current/link$|\1:\2|p' \
+                | sort -u); then
+            echo "===== registry.tar.bz2 image catalog ====="
+            echo "$catalog"
+            echo "===== end registry.tar.bz2 image catalog ====="
+            break
+        fi
+        if (( attempt >= max_attempts )); then
+            echo "ERROR: registry.tar.bz2 still corrupt/unavailable after ${max_attempts} attempts." >&2
+            exit 1
+        fi
+        echo "Download failed integrity check; retrying in 15s..." >&2
+        sleep 15
+        (( attempt++ ))
+    done
 fi
 
 log_disk_usage "after metalbox downloads"


### PR DESCRIPTION
## Problem

The `metalbox` element downloads the ~3.9 GB registry volume archive
`registry.tar.bz2` from object storage and lists it with `tar tjf`
(`elements/metalbox/install.d/40-install`). The download was unguarded —
whatever `wget` wrote was used as-is. When the downloaded copy is corrupt, the
build aborts ~30 minutes in at the catalog step:

```
bzip2: Data integrity error when decompressing.
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
```

## This is recurring, not a one-off

The same failure has hit `openstack-ironic-images-publish-metalbox`
(periodic-daily) at least three times over three months:

- 2026-07-21 — https://logs.services.osism.tech/930/osism/93098085451e423f8703294693d7a46f/
- 2026-06-21 — https://logs.services.osism.tech/c0f/osism/c0f6daebd9584d768757c5c4880bfe65/
- 2026-04-28 — https://logs.services.osism.tech/062/osism/062f6d29a1694220b29efc686f2281f3/

Each shows the identical `bzip2: Data integrity error` / `tar: Unexpected EOF`
in the `Run build script` task.

## Root cause

Download-path corruption, **not** a bad published artifact. For the 2026-07-21
occurrence the stored object was verified intact when fetched independently:
its bytes matched the uploader's stored `x-amz-meta-md5chksum`, and `bzip2 -t`
passed cleanly over all blocks. The object's `Last-Modified` was unchanged
across CI's fetch and that later verification.

CI received a **full-length but corrupt** copy: the object-storage endpoint
dropped the connection mid-stream and returned a `504` on the preceding tries,
then delivered a full-length body that `wget` reported as a successful save.
Nothing verified the archive before use, so a transient object-storage fault
wasted the entire build. (Where exactly the bytes corrupted — server response
generation, an intermediary, or transient delivery — is not pinned down; the
fix does not depend on which.)

## Fix

Wrap the download in a retry loop that verifies each copy before use. The
existing `tar tjf` catalog listing **doubles as the integrity gate**: `tar -j`
fully decompresses the stream, so a corrupt/truncated archive fails the
pipeline (non-zero under `pipefail`) and triggers a clean re-download instead
of poisoning the build. Net decompression stays at one pass — the catalog was
already decompressing the whole archive.

- Each attempt starts from a removed file (`rm -f`), so nothing layers onto a
  previous partial.
- `wget --tries=3 --timeout=120` rides out transient connection drops while
  fetching a complete body; the integrity gate decides good-vs-corrupt.
- After 4 failed attempts the build fails with an explicit message instead of
  a cryptic `tar` error.

The `build.yml` freshness check is intentionally untouched — it verifies
recency, not integrity, and already has its own retry loop.

## Testing

The build-time path can't be unit-tested against the real 3.9 GB fetch, so the
loop logic was exercised locally with a mock `wget` against good and
deliberately-truncated `.bz2` fixtures:

- corrupt → corrupt → good: retries twice, prints the catalog once, exits 0
- always corrupt: exits 1 after 4 attempts
- good immediately: catalog once, no retry
- `wget` fails (dropped) twice → good: exits 0
- `wget` fails 4×: exits 1

`bash -n` and `shellcheck` are clean on the changed block.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
